### PR TITLE
Remova prefixo X-* segundo especificação RFC-6648

### DIFF
--- a/src/main/java/org/marking/lab/resources/Resource.java
+++ b/src/main/java/org/marking/lab/resources/Resource.java
@@ -6,8 +6,8 @@ public abstract class Resource {
 	
 	
 	protected void paginateResponse(Response response, long total, long limit, long offset) {
-		response.header("X-Total-Count", String.valueOf(total));
-		response.header("X-Response-Limit", String.valueOf(limit));
-		response.header("X-Response-Offset", String.valueOf(offset));
+		response.header("Total-Count", String.valueOf(total));
+		response.header("Response-Limit", String.valueOf(limit));
+		response.header("Response-Offset", String.valueOf(offset));
 	}
 }


### PR DESCRIPTION
Remova prefixo X-* segundo especificação RCF a seguir: 
https://tools.ietf.org/html/rfc6648